### PR TITLE
Simplify laziness of frames sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires `innmind/immutable:~5.7`
+- The `Sequence` of frames to publish a message is only lazy when the message content is a lazy sequence of chunks
+
 ## 5.0.0 - 2024-03-10
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "~5.2",
+        "innmind/immutable": "~5.7",
         "innmind/time-continuum": "~3.1",
         "innmind/math": "~6.0",
         "innmind/url": "~4.1",


### PR DESCRIPTION
## Problem

Currently a message can be expressed either via a `string` or a file `Content`. When sent over the wire this message is chunked into a sequence of frames.

In order to work with large files the sequence of frames is forced to be lazy. 

However this complexifies debugging the sequences when the message fits in memory.

## Solution

Derive the kind of sequence to use from the message content chunk sequence (thanks to `Sequence::prepend()`)